### PR TITLE
Bump AdaptiveCards from 2.7.3 to 3.1.0 in /GraphCalendarBot

### DIFF
--- a/GraphCalendarBot/GraphCalendarBot.csproj
+++ b/GraphCalendarBot/GraphCalendarBot.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AdaptiveCards" Version="2.7.3" />
+    <PackageReference Include="AdaptiveCards" Version="3.1.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.10" />
     <PackageReference Include="Microsoft.Bot.Builder.Dialogs" Version="4.21.1" />
     <PackageReference Include="Microsoft.Bot.Builder.Integration.AspNet.Core" Version="4.21.1" />


### PR DESCRIPTION
Bumps AdaptiveCards from 2.7.3 to 3.1.0.

---
updated-dependencies:
- dependency-name: AdaptiveCards dependency-type: direct:production update-type: version-update:semver-major ...